### PR TITLE
Updated openSkills.py and test_open_skills to V2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ permissions.py
 
 # internal-facing apis that aren't publicly accessible (yet)
 *skillClusters.py
+skills_list.xlsx

--- a/apis/openSkills.py
+++ b/apis/openSkills.py
@@ -2,6 +2,7 @@
 Summary
 """
 from .base import EmsiBaseConnection
+import json
 
 
 class SkillsClassificationConnection(EmsiBaseConnection):
@@ -141,8 +142,8 @@ class SkillsClassificationConnection(EmsiBaseConnection):
         Returns:
             TYPE: Description
         """
-        payload = {"ids": skill_ids}
-        return self.download_data("versions/{}/skills".format(version), payload = payload).json()
+        payload = json.dumps({"ids":  skill_ids})
+        return self.download_data("versions/{}/related".format(version), payload = payload).json()
 
     def post_extract(self, description: str, version: str = 'latest') -> dict:
         """Summary
@@ -166,4 +167,4 @@ class SkillsClassificationConnection(EmsiBaseConnection):
         Returns:
             dict: Description
         """
-        return self.download_data("versions/{}/extract".format(version), payload = description, querystring = {"trace":"true"}).json()
+        return self.download_data("versions/{}/extract/trace".format(version), payload = description).json()

--- a/tests/test_open_skills.py
+++ b/tests/test_open_skills.py
@@ -12,80 +12,56 @@ skills_conn = SkillsClassificationConnection()
 def test_get_status():
     response = skills_conn.get_status()
 
-    assert response.text == 'OK'
+    assert response.json()['data']['message'] == 'Service is healthy'
 
+def test_get_is_healthy():
+    response = skills_conn.is_healthy()
 
-def test_get_documentation():
-    response = skills_conn.get_documentation()
-
-    assert len(response) > 0
-
-def test_get_changelog():
-    response = skills_conn.get_changelog()
-
-    assert len(response) > 0
-
+    assert response == True
 
 def test_get_versions():
     response = skills_conn.get_versions()
 
-    assert len(response) >= 38
+    assert len(response['data']) >= 38
 
+def test_get_version_metadata():
+    response = skills_conn.get_version_metadata()
+    
+    assert float(response['data']['version']) >= 7.2
 
 def test_get_list_all_skills():
     response = skills_conn.get_list_all_skills()
 
-    assert len(response['skills']) > 29000
+    assert len(response['data']) > 29000
 
 def test_post_list_requested_skills():
-    skills = "{\"skills\" : [{\"id\":\"KS1200364C9C1LK3V5Q1\"},{\"id\":\"KS1275N74XZ574T7N47D\"}, {\"id\":\"KS125QD6K0QLLKCTPJQ0\"}]}"
+    skills = "{ \"ids\": [ \"KS1200364C9C1LK3V5Q1\", \"KS1275N74XZ574T7N47D\", \"KS125QD6K0QLLKCTPJQ0\" ] }"
     response = skills_conn.post_list_requested_skills(payload = skills)
 
-    assert len(response['skills']) == 3
-
-
-def test_get_search_skills():
-    response = skills_conn.get_search_skills(skill_name = 'python')
-
-    assert len(response['skills']) > 1
-
-
-def test_get_skills_fields():
-    fields = {"fields":"id,tags"}
-    skills = "{\"skills\" : [{\"id\":\"KS1200364C9C1LK3V5Q1\"}, {\"id\":\"KS1275N74XZ574T7N47D\"}, {\"id\":\"KS125QD6K0QLLKCTPJQ0\"}]}"
-    response = skills_conn.post_list_requested_skills(payload = skills, querystring = fields)
-
-    assert len(response['skills']) == 3
-
+    assert len(response['data']) == 3
 
 def test_get_skill_by_id():
     skill_id = 'KS125LS6N7WP4S6SFTCK'
     response = skills_conn.get_skill_by_id(skill_id = skill_id)
 
-    assert response['name'] == 'Python (Programming Language)'
+    assert response['data']['name'] == 'Python (Programming Language)'
 
-def test_get_fields():
-    response = skills_conn.get_fields()
+def test_post_find_related_skills():
+    skills = [ "KS1200364C9C1LK3V5Q1", "KS1275N74XZ574T7N47D", "KS125QD6K0QLLKCTPJQ0" ]
+    response = skills_conn.post_find_related_skills(skill_ids = skills)
 
-    for field in ['id', 'name', 'tags', 'type', 'default']:
-        assert field in [d['key'] for d in response['fields']]
-
-def test_get_skill_types():
-    response = skills_conn.get_skill_types()
-
-    for skill_type in ['Hard Skill', 'Certification', 'Soft Skill']:
-        assert skill_type in [d['name'] for d in response['types']]
+    assert len(response['data']) > 1
 
 def test_post_extract():
-    job_description = "{\"full_text\" : \"... Great candidates also have\n\n Experience with a particular JS MV* framework (we happen to use React)\n Experience working with databases\n Experience with AWS\n Familiarity with microservice architecture\n Familiarity with modern CSS practices, e.g. LESS, SASS, CSS-in-JS ...\"}"
+    job_description = "{ \"text\": \"... Great candidates also have\\n\\n Experience with a particular JS MV* framework (we happen to use React)\\n Experience working with databases\\n Experience with AWS\\n Familiarity with microservice architecture\\n Familiarity with modern CSS practices, e.g. LESS, SASS, CSS-in-JS ...\"}"
 
     response = skills_conn.post_extract(description = job_description)
     for skill in ['JavaScript (Programming Language)', 'React.js', 'Amazon Web Services', 'Cascading Style Sheets (CSS)']:
-        assert skill in [d['name'] for d in [e['skill'] for e in response['skills']]]
+        assert skill in [d['name'] for d in [e['skill'] for e in response['data']]]
 
 def test_post_extract_with_source():
-    job_description = "{\"full_text\" : \"... Great candidates also have\n\n Experience with a particular JS MV* framework (we happen to use React)\n Experience working with databases\n Experience with AWS\n Familiarity with microservice architecture\n Familiarity with modern CSS practices, e.g. LESS, SASS, CSS-in-JS ...\"}"
+    job_description = "{ \"text\": \"... Great candidates also have\\n\\n Experience with a particular JS MV* framework (we happen to use React)\\n Experience working with databases\\n Experience with AWS\\n Familiarity with microservice architecture\\n Familiarity with modern CSS practices, e.g. LESS, SASS, CSS-in-JS ...\"}"
 
     response = skills_conn.post_extract_with_source(description = job_description)
 
-    assert len(response['trace']) > 0
+    assert len(response['data']) > 0


### PR DESCRIPTION
This PR updates two endpoints in the openSkills.py to work with V2 of the API and updates one payload to be json.  It also updates the test file and adds to .gitignore the file created by the new sample/download_skills.py.  For that sample you might need to add openpyxl to the requirements list.